### PR TITLE
Vagrant Apache2 Static Files Fix

### DIFF
--- a/cookbooks/django/recipes/default.rb
+++ b/cookbooks/django/recipes/default.rb
@@ -20,6 +20,7 @@ file "/etc/apache2/sites-available/project" do
 			AuthDBMUserFile /vagrant/api_password_file
 			Require valid-user
 		</Location>
+		Alias /static/ /vagrant/static/
     </VirtualHost>"
 end
 


### PR DESCRIPTION
This will fix the vagrant issue. So when running with WSGI on Apache2, it neglects the static files, so I'm having Apache2 serve the static files instead.
