### PR TITLE
Added pillow to vagrant installation

### DIFF
--- a/cookbooks/django/recipes/default.rb
+++ b/cookbooks/django/recipes/default.rb
@@ -1,3 +1,4 @@
+python_pip "pillow"
 python_pip "django"
 python_pip "commonmark"
 


### PR DESCRIPTION
This will install pillow for Django to work properly on Vagrant only. Every where else works.

Remember to run this to reprovision if you use Vagrant:

```
vagrant provision
```
