### PR TITLE
authors endpoint now returns all profiles.

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -21,6 +21,10 @@ urlpatterns = patterns('api.views',
 
                        # POST authors, returns list of friends in the list
                        (r'^friends/(?P<author_id>{})/?$'.format(id_regex), 'get_friends'),
+
+                       # GET authors on our server
+                       (r'^authors$', 'get_authors'),
+
                        # Make a friend request with another user
                        (r'^friendrequest$', 'friend_request'),
 

--- a/api/views.py
+++ b/api/views.py
@@ -248,7 +248,6 @@ def get_foaf_servers(profile, author, friends):
         return True
 
 
-# @login_required
 @auth_as_user()
 @require_http_methods(["GET"])
 @require_http_accept(['application/json'])
@@ -286,7 +285,6 @@ def get_posts(request, author_id=None, page="0"):
     return JsonResponse(data)
 
 
-# @login_required
 @csrf_exempt
 @require_http_methods(["GET", "POST"])
 @require_http_accept(['application/json'])
@@ -345,12 +343,10 @@ def get_post(request, post_id=None, page="0"):
     return JsonResponse({"posts": return_data})
 
 
-#@login_required
 @csrf_exempt
 @require_http_methods(["POST"])
 @require_http_accept(['application/json'])
 @require_http_content_type(['application/json'])
-#@http_error_code(501,"Not Implemented")
 def friend_request(request, page="0"):
     # get data from request
     data = None
@@ -404,6 +400,18 @@ def friend_request(request, page="0"):
 
         return HttpResponseBadRequest()
 
+@csrf_exempt
+@require_http_methods(["GET"])
+@require_http_accept(['application/json'])
+@require_http_content_type(['application/json'])
+def get_authors(request):
+    # get all accepted friends
+    profiles = model_list(Profile.objects.all())
+    # for profile in profiles:
+        # delete github_username?
+
+    return JsonResponse({"authors": profiles})
+
 
 #TODO PUT THIS IN COMMON PLACE THIS IS FROM
 # THE FRIENDS APP
@@ -418,7 +426,6 @@ def get_other_profiles(profile, query):
     return profiles
 
 
-#@login_required
 @csrf_exempt
 @require_http_methods(["POST"])
 @require_http_accept(['application/json'])
@@ -487,7 +494,6 @@ def follow_user(request):
         print e.message
 
 
-#@login_required
 @require_http_methods(["GET"])
 @require_http_accept(['application/json'])
 @require_http_content_type(['application/json'])

--- a/user_profile/models.py
+++ b/user_profile/models.py
@@ -31,7 +31,7 @@ class Profile(GUIDModel):
     def as_dict(self):
         return {
             "id": self.guid,  # TODO implement host
-            "host": "",
+            "host": self.host,
             "displayname": self.display_name,
             "url": self.host + "/author/" + self.guid,
             "github_name": self.github_name


### PR DESCRIPTION
This assumes we only store profiles from our own server. Could add a filter for our server as host if this assumption is untrue.
Once merged should satisfy https://github.com/grepme/cmput410-project/issues/111
(Should also let Dan know)
