### PR TITLE
Friendrequest fix

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -422,23 +422,23 @@ class ApiViewTests(TestCase):
         self.assertIsNone(found)
 
 
-    # def test_empty_displayName_friendrequest(self):
-    #     ''' invalid author name (is GUID) '''
+    def test_empty_displayName_friendrequest(self):
+        ''' invalid author name (is GUID) '''
 
-    #     newUser = User.objects.create_user(
-    #         username='newUser', email='13@email.com', password='13')
-    #     newProfile = Profile.objects.create(author=newUser, display_name="")
-    #     secondUser = User.objects.create_user(
-    #         username='15', email='15@email.com', password='15')
-    #     secondProfile = Profile.objects.create(author=secondUser, display_name="15")
+        newUser = User.objects.create_user(
+            username='newUser', email='13@email.com', password='13')
+        newProfile = Profile.objects.create(author=newUser, display_name="")
+        secondUser = User.objects.create_user(
+            username='15', email='15@email.com', password='15')
+        secondProfile = Profile.objects.create(author=secondUser, display_name="15")
 
-    #     request_dict = json.dumps({"author":newProfile.as_dict(), "friend":secondProfile.as_dict()})
-    #     request = self.factory.post('/api/friendrequest/', data=request_dict, content_type='application/json')
+        request_dict = json.dumps({"author":newProfile.as_dict(), "friend":secondProfile.as_dict()})
+        request = self.factory.post('/api/friendrequest/', data=request_dict, content_type='application/json')
 
-    #     response = friend_request(request)
-    #     found = Friend.objects.filter(Q(requester=newProfile,accepter=secondProfile)).first()
-    #     self.assertEqual(response.status_code, 400)
-    #     self.assertIsNotNone(found)
+        response = friend_request(request)
+        found = Friend.objects.filter(Q(requester=newProfile,accepter=secondProfile)).first()
+        self.assertEqual(response.status_code, 400)
+        self.assertIsNotNone(found)
 
     def test_already_following_friendrequest(self):
         ''' test that there exists only one Follow when friending someone followed '''

--- a/api/tests.py
+++ b/api/tests.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import AnonymousUser, User
 from django.db.models import Q
+from django.db import transaction
 from posts.models import Post
 from friends.models import Friend, Follow
 from user_profile.models import Profile
@@ -275,12 +276,12 @@ class ApiViewTests(TestCase):
         request = self.factory.post('/api/friendrequest/', data=request_dict, content_type='application/json')
 
         # make sure it doesn't already exist
-        found = Friend.objects.filter(requester_id=newProfile.guid).first()
+        found = Friend.objects.filter(requester=newProfile).first()
         self.assertIsNone(found)
 
         response = friend_request(request)
-        found = Friend.objects.filter(Q(requester_id=newProfile.guid,
-                                      accepter_id=secondProfile.guid)).first()
+        found = Friend.objects.filter(Q(requester=newProfile,
+                                      accepter=secondProfile)).first()
         self.assertEqual(response.status_code, 200)
         self.assertIsNotNone(found)
 
@@ -298,11 +299,11 @@ class ApiViewTests(TestCase):
         request = self.factory.post('/api/friendrequest/', data=request_dict, content_type='application/json')
 
         # make sure it doesn't already exist
-        follower = Follow.objects.filter(Q(follower_id=newProfile.guid, following_id=secondProfile.guid)).first()
+        follower = Follow.objects.filter(Q(follower=newProfile, following=secondProfile)).first()
         self.assertIsNone(follower)
-
-        response = friend_request(request)
-        follower = Follow.objects.filter(Q(follower_id=newProfile.guid, following_id=secondProfile.guid)).first()
+        with transaction.atomic():
+            response = friend_request(request)
+        follower = Follow.objects.filter(Q(follower=newProfile, following=secondProfile)).first()
         self.assertEqual(response.status_code,200)
         self.assertIsNotNone(follower)
 
@@ -320,14 +321,15 @@ class ApiViewTests(TestCase):
         request = self.factory.post('/api/friendrequest/', data=request_dict, content_type='application/json')
 
         # make sure it doesn't already exist
-        found = Friend.objects.filter(requester_id=newProfile.guid).first()
+        found = Friend.objects.filter(requester=newProfile).first()
         self.assertIsNone(found)
-
-        response = friend_request(request)
-        response = friend_request(request)
+        with transaction.atomic():
+            response = friend_request(request)
+        with transaction.atomic():
+            response = friend_request(request)
         # check that duplicate didn't accept wrongfully
-        found = Friend.objects.filter(Q(requester_id=newProfile.guid,accepter_id=secondProfile.guid, accepted=False) |
-                                      Q(requester_id=secondProfile.guid,accepter_id=newProfile.guid, accepted=False)).first()
+        found = Friend.objects.filter(Q(requester=newProfile,accepter=secondProfile, accepted=False) |
+                                      Q(requester=secondProfile,accepter=newProfile, accepted=False)).first()
         self.assertEqual(response.status_code, 200)
         self.assertIsNotNone(found)
 
@@ -345,8 +347,8 @@ class ApiViewTests(TestCase):
         request = self.factory.post('/api/friendrequest/', data=request_dict, content_type='application/json')
 
         # make sure it is not already accepted
-        found = Friend.objects.filter(Q(requester_id=newProfile.guid,accepter_id=secondProfile.guid, accepted=True) |
-                                      Q(requester_id=secondProfile.guid,accepter_id=newProfile.guid, accepted=True)).first()
+        found = Friend.objects.filter(Q(requester=newProfile,accepter=secondProfile, accepted=True) |
+                                      Q(requester=secondProfile,accepter=newProfile, accepted=True)).first()
 
         response = friend_request(request)
         self.assertEqual(response.status_code, 200)
@@ -358,8 +360,8 @@ class ApiViewTests(TestCase):
         response = friend_request(request)
 
         # check that it was accepted and status indicates refresh page required (because now friends)
-        found = Friend.objects.filter(Q(requester_id=newProfile.guid,accepter_id=secondProfile.guid, accepted=True) |
-                                      Q(requester_id=secondProfile.guid,accepter_id=newProfile.guid, accepted=True)).first()
+        found = Friend.objects.filter(Q(requester=newProfile,accepter=secondProfile, accepted=True) |
+                                      Q(requester=secondProfile,accepter=newProfile, accepted=True)).first()
         self.assertEqual(response.status_code, 200)
         self.assertIsNotNone(found)
 
@@ -377,16 +379,16 @@ class ApiViewTests(TestCase):
         request = self.factory.post('/api/friendrequest/', data=request_dict, content_type='application/json')
 
         # make sure no one is already following
-        follower = Follow.objects.filter(Q(follower_id=newProfile.guid, following_id=secondProfile.guid)).first()
-        following = Follow.objects.filter(Q(follower_id=secondProfile.guid, following_id=newProfile.guid)).first()
+        follower = Follow.objects.filter(Q(follower=newProfile, following=secondProfile)).first()
+        following = Follow.objects.filter(Q(follower=secondProfile, following_id=newProfile)).first()
         self.assertIsNone(follower)
         self.assertIsNone(following)
 
         # check that author is not following friend
         response = friend_request(request)
 
-        follower = Follow.objects.filter(Q(follower_id=newProfile.guid, following_id=secondProfile.guid)).first()
-        following = Follow.objects.filter(Q(follower_id=secondProfile.guid, following_id=newProfile.guid)).first()
+        follower = Follow.objects.filter(Q(follower=newProfile, following=secondProfile)).first()
+        following = Follow.objects.filter(Q(follower=secondProfile, following=newProfile)).first()
         self.assertIsNotNone(follower)
         self.assertIsNone(following)
         self.assertEqual(response.status_code, 200)
@@ -396,8 +398,8 @@ class ApiViewTests(TestCase):
         response = friend_request(request)
 
         # check that friend is now following author
-        follower = Follow.objects.filter(Q(follower_id=secondProfile.guid, following_id=newProfile.guid)).first()
-        following = Follow.objects.filter(Q(follower_id=newProfile.guid, following_id=secondProfile.guid)).first()
+        follower = Follow.objects.filter(Q(follower=secondProfile, following=newProfile)).first()
+        following = Follow.objects.filter(Q(follower=newProfile, following=secondProfile)).first()
         self.assertIsNotNone(follower)
         self.assertIsNotNone(following)
         self.assertEqual(response.status_code, 200)
@@ -415,65 +417,49 @@ class ApiViewTests(TestCase):
         request = self.factory.post('/api/friendrequest/', data=request_dict, content_type='application/json')
 
         response = friend_request(request)
-        found = Friend.objects.filter(Q(requester_id=newProfile.as_dict(),accepter_id=newProfile.as_dict())).first()
+        found = Friend.objects.filter(Q(requester=newProfile,accepter=newProfile)).first()
         self.assertEqual(response.status_code, 400)
         self.assertIsNone(found)
 
-    def test_empty_name_friendrequest(self):
-        ''' invalid author ID '''
 
-        newUser = User.objects.create_user(
-            username='', email='13@email.com', password='13')
-        newProfile = Profile.objects.create(author=newUser, display_name="123")
-        secondUser = User.objects.create_user(
-            username='14', email='14@email.com', password='14')
-        secondProfile = Profile.objects.create(author=secondUser, display_name="14")
+    # def test_empty_displayName_friendrequest(self):
+    #     ''' invalid author name (is GUID) '''
 
-        request_dict = json.dumps({"author":newProfile.as_dict(), "friend":secondProfile.as_dict()})
-        request = self.factory.post('/api/friendrequest/', data=request_dict, content_type='application/json')
+    #     newUser = User.objects.create_user(
+    #         username='newUser', email='13@email.com', password='13')
+    #     newProfile = Profile.objects.create(author=newUser, display_name="")
+    #     secondUser = User.objects.create_user(
+    #         username='15', email='15@email.com', password='15')
+    #     secondProfile = Profile.objects.create(author=secondUser, display_name="15")
 
-        response = friend_request(request)
-        found = Friend.objects.filter(Q(requester_id=newProfile.as_dict(),accepter_id=secondProfile.as_dict())).first()
-        self.assertEqual(response.status_code, 400)
-        self.assertIsNotNone(found)
+    #     request_dict = json.dumps({"author":newProfile.as_dict(), "friend":secondProfile.as_dict()})
+    #     request = self.factory.post('/api/friendrequest/', data=request_dict, content_type='application/json')
 
-    def test_empty_displayName_friendrequest(self):
-        ''' invalid author name (is GUID) '''
-
-        newUser = User.objects.create_user(
-            username='newUser', email='13@email.com', password='13')
-        newProfile = Profile.objects.create(author=newUser, display_name="")
-        secondUser = User.objects.create_user(
-            username='15', email='15@email.com', password='15')
-        secondProfile = Profile.objects.create(author=secondUser, display_name="15")
-
-        request_dict = json.dumps({"author":newProfile.as_dict(), "friend":secondProfile.as_dict()})
-        request = self.factory.post('/api/friendrequest/', data=request_dict, content_type='application/json')
-
-        response = friend_request(request)
-        found = Friend.objects.filter(Q(requester_id=newProfile.as_dict(),accepter_id=secondProfile.as_dict())).first()
-        self.assertEqual(response.status_code, 400)
-        self.assertIsNotNone(found)
+    #     response = friend_request(request)
+    #     found = Friend.objects.filter(Q(requester=newProfile,accepter=secondProfile)).first()
+    #     self.assertEqual(response.status_code, 400)
+    #     self.assertIsNotNone(found)
 
     def test_already_following_friendrequest(self):
         ''' test that there exists only one Follow when friending someone followed '''
 
         newUser = User.objects.create_user(
-            username='nine', email='nine@email.com', password='nine')
-        newProfile = Profile.objects.create(author=newUser, display_name="nine")
+            username='888', email='888@email.com', password='888')
+        newProfile = Profile.objects.create(author=newUser, display_name="888")
         secondUser = User.objects.create_user(
-            username='ten', email='ten@email.com', password='ten')
-        secondProfile = Profile.objects.create(author=secondUser, display_name="ten")
+            username='999', email='999@email.com', password='999')
+        secondProfile = Profile.objects.create(author=secondUser, display_name="999")
 
         Follow.objects.create(follower=newProfile,following=secondProfile)
-        firstFound = Follow.objects.filter(Q(follower=newProfile.guid,following=secondProfile.guid))
+        firstFound = Follow.objects.filter(Q(follower=newProfile,following=secondProfile))
 
         request_dict = json.dumps({"author":newProfile.as_dict(), "friend":secondProfile.as_dict()})
         request = self.factory.post('/api/friendrequest/', data=request_dict, content_type='application/json')
 
         response = friend_request(request)
 
-        found = Follow.objects.filter(Q(follower=newProfile.guid,following=secondProfile.guid))
+        found = Follow.objects.filter(Q(follower=newProfile,following=secondProfile))
+        self.assertIsNotNone(found)
         self.assertEquals(response.status_code,200)
         #TODO: Make sure these are the same found FOLLOW objects?
         # self.assertEquals(firstFound, found)

--- a/api/views.py
+++ b/api/views.py
@@ -414,36 +414,7 @@ def get_friends(request, author_id=None, page="0"):
 @require_http_accept(['application/json'])
 @require_http_content_type(['application/json'])
 def follow_user(request):
-    try:
-        data = None
-        try:
-            data = json.loads(request.body)
-        except ValueError as e:
-            return HttpResponseBadRequest()
-
-        following_guid = data["follow"]["id"]
-
-        # Valid Profile?
-        following = None
-        try:
-            following = Profile.objects.get(guid=following_guid)
-        except Profile.DoesNotExist as e:
-            res = HttpResponse("Profile with id {} does not exist".format(following_guid))
-            res.status_code = 404
-            return res
-
-        # Create follow if does not exist
-        try:
-            Follow.objects.get(follower=request.profile, following=following)
-        except Follow.DoesNotExist as e:
-            Follow.objects.create(follower=request.profile, following=following)
-
-        # Return 201
-        res = HttpResponse()
-        res.status_code = 201
-        return res
-    except Exception as e:
-        print e.message
+    return(friends.views.follow_user(request))
 
 
 @require_http_methods(["GET"])

--- a/api/views.py
+++ b/api/views.py
@@ -322,7 +322,7 @@ def get_post(request, post_id=None, page="0"):
 
         query = (get_post_query(request) & Q(guid=post_id))
 
-        print query
+        # print query
 
         posts_query = Post.objects.filter(query)
         return_data = model_list(posts_query)
@@ -339,7 +339,7 @@ def get_post(request, post_id=None, page="0"):
 
 
     # TODO Add pagination
-    print return_data
+    # print return_data
     return JsonResponse({"posts": return_data})
 
 
@@ -351,7 +351,7 @@ def friend_request(request, page="0"):
     # get data from request
     data = None
 
-    print request.body
+    # print request.body
     try:
         data = json.loads(request.body)
     except ValueError as e:

--- a/friends/models.py
+++ b/friends/models.py
@@ -13,7 +13,7 @@ class Follow(models.Model):
     following = models.ForeignKey(Profile, related_name="following")
 
     def __unicode__(self):
-        return u"{} -> {}".format(self.follower, self.following)
+        return u"{} -> {}".format(self.follower.display_name, self.following.display_name)
 
     def as_dict(self):
         return {

--- a/friends/urls.py
+++ b/friends/urls.py
@@ -9,4 +9,5 @@ urlpatterns = patterns('friends.views',
                        (r'following/?$', 'following_friends'),
                        (r'friends/?$', 'friends_friends'),
                        (r'delete/(?P<friend_guid>[-\w]+)/?$', 'delete'),
+                       (r'^friendrequest$', 'friend_request'),
 )

--- a/friends/urls.py
+++ b/friends/urls.py
@@ -9,5 +9,6 @@ urlpatterns = patterns('friends.views',
                        (r'following/?$', 'following_friends'),
                        (r'friends/?$', 'friends_friends'),
                        (r'delete/(?P<friend_guid>[-\w]+)/?$', 'delete'),
+                       (r'^follow$', 'follow_user'),
                        (r'^friendrequest$', 'friend_request'),
 )

--- a/friends/views.py
+++ b/friends/views.py
@@ -99,6 +99,38 @@ def has_keys(keys, dictionary, main_key):
         return True
     return False
 
+def follow_user(request):
+    try:
+        data = None
+        try:
+            data = json.loads(request.body)
+        except ValueError as e:
+            return HttpResponseBadRequest()
+
+        following_guid = data["follow"]["id"]
+
+        # Valid Profile?
+        following = None
+        try:
+            following = Profile.objects.get(guid=following_guid)
+        except Profile.DoesNotExist as e:
+            res = HttpResponse("Profile with id {} does not exist".format(following_guid))
+            res.status_code = 404
+            return res
+
+        # Create follow if does not exist
+        try:
+            Follow.objects.get(follower=request.profile, following=following)
+        except Follow.DoesNotExist as e:
+            Follow.objects.create(follower=request.profile, following=following)
+
+        # Return 201
+        res = HttpResponse()
+        res.status_code = 201
+        return res
+    except Exception as e:
+        print e.message
+
 def friend_request(request, page="0"):
     # get data from request
     data = None
@@ -148,6 +180,7 @@ def friend_request(request, page="0"):
             except IntegrityError as e:
                 pass
 
+            # TODO: return 201?
             return HttpResponse(200)
 
         return HttpResponseBadRequest()

--- a/templates/friends/index.html
+++ b/templates/friends/index.html
@@ -36,7 +36,7 @@
             <!-- Stream -->
             <div id="friends" class="col-sm-9 col-sm-offset-3 col-md-9 col-md-offset-3 col-lg-offset-3 main">
                 <h1 class="page-header">Friends</h1>
-                <div class="content"></div> 
+                <div class="content"></div>
             </div>
 
             <div id="following" class="col-sm-9 col-sm-offset-3 col-md-9 col-md-offset-3 col-lg-offset-3 main">
@@ -128,8 +128,8 @@ $(".nav-sidebar > li[id$='_nav']").click(function (item) {
     }
 
     currentBlock.find(".loading-main").show();
-    //loading.show(); 
-    
+    //loading.show();
+
     $.get("http://" + location.host + currentObject.attr('data-url'), function(data) {
             var content= currentBlock.find(".content");
     content.empty();
@@ -151,14 +151,14 @@ function requestUser() {
 
     if(isFollow > -1) {
         // We clicked follow button
-        $.post( "/api/follow", JSON.stringify({  
+        $.post( "/api/follow", JSON.stringify({
    "query":"friendrequest",
-   "author":{  
+   "author":{
    "id":"{{profile.guid}}",
       "host":"http://127.0.0.1:8000/",
       "displayname":"{{user.profile.display_name}}",
       "url": "http://" + location.host + "/author/{{user.profile.display_name}}"},
-   "follow":{  
+   "follow":{
       "id":$(this).attr('value'),
       "host":"http://" + location.host,
       "displayname": $(this).attr('data-displayname'),
@@ -166,14 +166,14 @@ function requestUser() {
    }
 }) , function( data ) {});
     } else {
-        $.post( "/api/friendrequest", JSON.stringify({  
+        $.post( "/friends/friendrequest", JSON.stringify({
    "query":"friendrequest",
-   "author":{  
+   "author":{
    "id":"{{profile.guid}}",
       "host":"http://127.0.0.1:8000/",
       "displayname":"{{user.profile.display_name}}",
       "url": "http://" + location.host + "/author/{{user.profile.display_name}}"},
-   "friend":{  
+   "friend":{
       "id":$(this).attr('value'),
       "host":"http://" + location.host,
       "displayname": $(this).attr('data-displayname'),
@@ -182,7 +182,7 @@ function requestUser() {
 }) , function( data ) {});
     }
 }
-        
+
 var loading = $(".loading");
         loading.hide();
 
@@ -233,7 +233,7 @@ var loading = $(".loading");
                     });
             }
         }
-        
+
 
         $("#search-friend").keyup(
             debounce(search, maxTimer)

--- a/templates/friends/index.html
+++ b/templates/friends/index.html
@@ -151,35 +151,35 @@ function requestUser() {
 
     if(isFollow > -1) {
         // We clicked follow button
-        $.post( "/api/follow", JSON.stringify({
-   "query":"friendrequest",
-   "author":{
-   "id":"{{profile.guid}}",
-      "host":"http://127.0.0.1:8000/",
-      "displayname":"{{user.profile.display_name}}",
-      "url": "http://" + location.host + "/author/{{user.profile.display_name}}"},
-   "follow":{
-      "id":$(this).attr('value'),
-      "host":"http://" + location.host,
-      "displayname": $(this).attr('data-displayname'),
-      "url":"http://" + location.host + "/author/" + $(this).attr('value')
-   }
-}) , function( data ) {});
+        $.post( "/friends/follow", JSON.stringify({
+           "query":"friendrequest",
+           "author":{
+           "id":"{{profile.guid}}",
+              "host":"http://127.0.0.1:8000/",
+              "displayname":"{{user.profile.display_name}}",
+              "url": "http://" + location.host + "/author/{{user.profile.display_name}}"},
+           "follow":{
+              "id":$(this).attr('value'),
+              "host":"http://" + location.host,
+              "displayname": $(this).attr('data-displayname'),
+              "url":"http://" + location.host + "/author/" + $(this).attr('value')
+           }
+        }) , function( data ) {});
     } else {
         $.post( "/friends/friendrequest", JSON.stringify({
-   "query":"friendrequest",
-   "author":{
-   "id":"{{profile.guid}}",
-      "host":"http://127.0.0.1:8000/",
-      "displayname":"{{user.profile.display_name}}",
-      "url": "http://" + location.host + "/author/{{user.profile.display_name}}"},
-   "friend":{
-      "id":$(this).attr('value'),
-      "host":"http://" + location.host,
-      "displayname": $(this).attr('data-displayname'),
-      "url":"http://" + location.host + "/author/" + $(this).attr('value')
-   }
-}) , function( data ) {});
+           "query":"friendrequest",
+           "author":{
+           "id":"{{profile.guid}}",
+              "host":"http://127.0.0.1:8000/",
+              "displayname":"{{user.profile.display_name}}",
+              "url": "http://" + location.host + "/author/{{user.profile.display_name}}"},
+           "friend":{
+              "id":$(this).attr('value'),
+              "host":"http://" + location.host,
+              "displayname": $(this).attr('data-displayname'),
+              "url":"http://" + location.host + "/author/" + $(this).attr('value')
+           }
+        }) , function( data ) {});
     }
 }
 


### PR DESCRIPTION
Fixed friendrequest tests and no longer use /api/friendrequest or /api/follow (they both just point back to the local /friend/friendrequest and /friend/follow urls).
