### PR TITLE
Puts the posts before github

### DIFF
--- a/templates/framework/dashboard.html
+++ b/templates/framework/dashboard.html
@@ -116,7 +116,7 @@
                      <div class="row col-md-10" style="margin: 0; padding: 0;">
                         {% include 'posts/github_feed.html' %}
                     </div>
-                </div>
+                    </div>
                 </div>
 
             </div>

--- a/templates/framework/dashboard.html
+++ b/templates/framework/dashboard.html
@@ -113,6 +113,9 @@
                     <div class="row col-md-10" style="margin: 0; padding: 0;">
                         {% include 'posts/all.html' %}
                     </div>
+                     <div class="row col-md-10" style="margin: 0; padding: 0;">
+                        {% include 'posts/github_feed.html' %}
+                    </div>
                 </div>
                 </div>
 

--- a/templates/framework/dashboard.html
+++ b/templates/framework/dashboard.html
@@ -113,6 +113,9 @@
                     <div class="row col-md-10" style="margin: 0; padding: 0;">
                         {% include 'posts/all.html' %}
                     </div>
+		    <div class="row col-md-10" style="margin: 0; padding: 0;">
+                        {% include 'posts/github_stream.html' %}
+                    </div>
                 </div>
                 </div>
 


### PR DESCRIPTION
This puts the posts before the github stream. I'll keep working on trying to reduce the number of github posts but if not, this is better then having the posts on the bottom. Needs to be added regardless--got deleted somehow.
